### PR TITLE
Add token-based Slearn map

### DIFF
--- a/src/ivi/__init__.py
+++ b/src/ivi/__init__.py
@@ -12,6 +12,7 @@ from .philosophical_heuristics import (
 )
 from .decentralized_scoring import Agent, ScoringSystem
 from .token import TokenLedger
+from .slearn import SlearnMap, LearningNode
 from .ecosystem import IVIEcosystem
 
 __all__ = [
@@ -30,5 +31,7 @@ __all__ = [
     "Agent",
     "ScoringSystem",
     "TokenLedger",
+    "SlearnMap",
+    "LearningNode",
     "IVIEcosystem",
 ]

--- a/src/ivi/ecosystem.py
+++ b/src/ivi/ecosystem.py
@@ -1,8 +1,3 @@
-
-New
-+100
--0
-
 from __future__ import annotations
 
 """High level integration utilities for the IVI ecosystem."""
@@ -16,6 +11,7 @@ from .traceability import IdeaTrace
 from .usefulness import UsefulnessRecord
 from .decentralized_scoring import Agent, ScoringSystem
 from .token import TokenLedger
+from .slearn import SlearnMap, LearningNode
 
 
 @dataclass
@@ -28,12 +24,19 @@ class IVIEcosystem:
     reputation: Dict[str, ReputationTrail] = field(default_factory=dict)
     scoring: Dict[str, ScoringSystem] = field(default_factory=dict)
     ledger: TokenLedger = field(default_factory=TokenLedger)
+    learning_map: SlearnMap | None = None
     last_scores: Dict[str, float] = field(default_factory=dict)
 
     impact_weight: float = 0.4
     trust_weight: float = 0.4
     alignment_weight: float = 0.2
     content_weight: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.learning_map is None:
+            self.learning_map = SlearnMap(ledger=self.ledger)
+        else:
+            self.learning_map.ledger = self.ledger
 
     def add_interaction(
         self, idea_id: str, user: str, tags: List[str], description: str
@@ -103,3 +106,9 @@ class IVIEcosystem:
             + self.alignment_weight * alignment
             + self.content_weight * content_score
         )
+
+    def add_learning_node(self, node: LearningNode) -> None:
+        self.learning_map.add_node(node)
+
+    def complete_lesson(self, user: str, node_id: str) -> bool:
+        return self.learning_map.complete_node(user, node_id)

--- a/src/ivi/slearn.py
+++ b/src/ivi/slearn.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple Slearn education map built on IVI tokens."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .token import TokenLedger
+
+
+@dataclass
+class LearningNode:
+    """Represents a lesson or goal in the learning map."""
+
+    node_id: str
+    required_tokens: float = 0.0
+    children: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SlearnMap:
+    """Track user progress through token-gated lessons."""
+
+    ledger: TokenLedger
+    nodes: Dict[str, LearningNode] = field(default_factory=dict)
+    progress: Dict[str, List[str]] = field(default_factory=dict)
+
+    def add_node(self, node: LearningNode) -> None:
+        self.nodes[node.node_id] = node
+
+    def available_nodes(self, user: str) -> List[str]:
+        balance = self.ledger.balance_of(user)
+        completed = set(self.progress.get(user, []))
+        return [
+            nid
+            for nid, node in self.nodes.items()
+            if nid not in completed and balance >= node.required_tokens
+        ]
+
+    def complete_node(self, user: str, node_id: str) -> bool:
+        if node_id not in self.available_nodes(user):
+            return False
+        self.progress.setdefault(user, []).append(node_id)
+        return True
+

--- a/tests/test_slearn.py
+++ b/tests/test_slearn.py
@@ -1,0 +1,15 @@
+from ivi.ecosystem import IVIEcosystem
+from ivi.belief_alignment import BeliefNode
+from ivi.slearn import LearningNode
+
+
+def test_slearn_unlocks_with_tokens():
+    tree = BeliefNode(label="growth")
+    tree.add_child(BeliefNode(label="success"))
+    eco = IVIEcosystem(belief_tree=tree)
+    eco.add_learning_node(LearningNode(node_id="lesson1", required_tokens=0.1))
+    eco.add_interaction("idea", user="alice", tags=["note"], description="x")
+    available = eco.learning_map.available_nodes("alice")
+    assert "lesson1" in available
+    assert eco.complete_lesson("alice", "lesson1")
+


### PR DESCRIPTION
## Summary
- fix IVIEcosystem header
- add new `SlearnMap` and `LearningNode`
- integrate `SlearnMap` with `IVIEcosystem`
- expose new classes from `ivi` package
- test unlocking a lesson with tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7356a1648328ae737455c48ee098