### PR TITLE
Add real-time dashboard and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ pytest
 └── README.md                   # This file
 ```
 
+## Real-Time Dashboard
+
+The optional `ivi.web` module exposes a FastAPI application that stores
+interactions in an SQLite database and streams updates via WebSocket.
+Launch the server with:
+
+```bash
+uvicorn ivi.web:app --reload
+```
+
+Then visit `/dashboard` to see a live feed of interactions.
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTIONS.md](CONTRIBUTIONS.md) for guidelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ license = {text = "MIT"}
 
 [project.optional-dependencies]
 test = ["pytest"]
+web = [
+    "fastapi",
+    "uvicorn",
+    "sqlalchemy",
+]
 
 [tool.pytest.ini_options]
 python_files = ["test_*.py"]

--- a/src/ivi/__init__.py
+++ b/src/ivi/__init__.py
@@ -15,6 +15,13 @@ from .token import TokenLedger
 from .slearn import SlearnMap, LearningNode
 from .ecosystem import IVIEcosystem
 
+try:  # optional real-time features
+    from .events import EventBus
+    from .database import User, Interaction, create_db
+except Exception:  # pragma: no cover - optional dependency missing
+    EventBus = None  # type: ignore
+    User = Interaction = create_db = None  # type: ignore
+
 __all__ = [
     "IdeaTrace",
     "semantic_provenance",
@@ -34,4 +41,8 @@ __all__ = [
     "SlearnMap",
     "LearningNode",
     "IVIEcosystem",
+    "EventBus",
+    "User",
+    "Interaction",
+    "create_db",
 ]

--- a/src/ivi/database.py
+++ b/src/ivi/database.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simple SQLAlchemy models for persistence."""
+
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+
+class Interaction(Base):
+    __tablename__ = "interactions"
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    idea_id = Column(String, nullable=False)
+    description = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User")
+
+def create_db(url: str = "sqlite:///:memory:") -> sessionmaker:
+    """Create tables and return a session factory."""
+    engine = create_engine(url, future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)

--- a/src/ivi/events.py
+++ b/src/ivi/events.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Simple event bus for IVI real-time updates."""
+
+import asyncio
+from typing import Any, Callable, List
+
+class EventBus:
+    """Basic in-memory event dispatcher."""
+
+    def __init__(self) -> None:
+        self.subscribers: List[Callable[[str, Any], Any]] = []
+
+    def subscribe(self, callback: Callable[[str, Any], Any]) -> None:
+        self.subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[str, Any], Any]) -> None:
+        if callback in self.subscribers:
+            self.subscribers.remove(callback)
+
+    async def publish(self, event_type: str, payload: Any) -> None:
+        for sub in list(self.subscribers):
+            try:
+                result = sub(event_type, payload)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                pass

--- a/src/ivi/web.py
+++ b/src/ivi/web.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Web server exposing real-time IVI updates via WebSocket."""
+
+import asyncio
+from fastapi import FastAPI, WebSocket
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from .ecosystem import IVIEcosystem
+from .events import EventBus
+from .database import create_db, User, Interaction
+
+app = FastAPI()
+bus = EventBus()
+SessionLocal = create_db()
+
+eco = IVIEcosystem()
+
+# Simple dashboard HTML
+DASHBOARD_HTML = """
+<!DOCTYPE html>
+<html>
+<head><title>IVI Dashboard</title></head>
+<body>
+<h1>IVI Live Interactions</h1>
+<ul id="events"></ul>
+<script>
+const ws = new WebSocket("ws://" + location.host + "/ws");
+ws.onmessage = (ev) => {
+  const data = JSON.parse(ev.data);
+  const li = document.createElement('li');
+  li.textContent = data.payload.user + ' -> ' + data.payload.idea_id + ' : ' + data.payload.description;
+  document.getElementById('events').appendChild(li);
+};
+</script>
+</body>
+</html>
+"""
+
+@app.get("/dashboard")
+async def dashboard() -> HTMLResponse:
+    return HTMLResponse(DASHBOARD_HTML)
+
+@app.post("/interactions")
+async def add_interaction(idea_id: str, user: str, description: str) -> dict:
+    session: Session = SessionLocal()
+    db_user = session.query(User).filter_by(name=user).first()
+    if not db_user:
+        db_user = User(name=user)
+        session.add(db_user)
+        session.commit()
+    interaction = Interaction(user=db_user, idea_id=idea_id, description=description)
+    session.add(interaction)
+    session.commit()
+    session.close()
+
+    eco.add_interaction(idea_id, user=user, tags=["note"], description=description)
+    await bus.publish("interaction", {"user": user, "idea_id": idea_id, "description": description})
+    return {"status": "ok"}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def handler(event: str, payload: dict) -> None:
+        queue.put_nowait({"type": event, "payload": payload})
+
+    bus.subscribe(handler)
+    try:
+        while True:
+            data = await queue.get()
+            await websocket.send_json(data)
+    except Exception:
+        pass
+    finally:
+        bus.unsubscribe(handler)
+        await websocket.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from ivi.database import create_db, User, Interaction
+
+
+def test_create_user_interaction():
+    Session = create_db("sqlite:///:memory:")
+    session = Session()
+    user = User(name="alice")
+    session.add(user)
+    session.commit()
+    inter = Interaction(user=user, idea_id="idea1", description="x")
+    session.add(inter)
+    session.commit()
+    assert session.query(User).count() == 1
+    assert session.query(Interaction).count() == 1
+    session.close()

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,0 +1,9 @@
+from ivi.events import EventBus
+import asyncio
+
+def test_event_bus_publish():
+    bus = EventBus()
+    received = []
+    bus.subscribe(lambda t, p: received.append((t, p)))
+    asyncio.run(bus.publish("ping", {"ok": True}))
+    assert received == [("ping", {"ok": True})]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+from ivi.web import app
+
+
+def test_dashboard_page():
+    client = TestClient(app)
+    res = client.get("/dashboard")
+    assert res.status_code == 200
+    assert "<html" in res.text.lower()


### PR DESCRIPTION
## Summary
- add optional `web` dependency group for realtime features
- implement simple SQLAlchemy models for users and interactions
- create event bus and FastAPI server with websocket endpoint
- expose optional modules in package init with graceful fallback
- document dashboard usage in the README
- provide tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7c273b3c832894ed5b9e1fb7e691